### PR TITLE
Package compatibility.

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,0 +1,2 @@
+#lang setup/infotab
+(define collection 'multi)

--- a/parsack/main.rkt
+++ b/parsack/main.rkt
@@ -1,0 +1,3 @@
+#lang racket
+(require "parsack.rkt")
+(provide (all-defined-out))


### PR DESCRIPTION
- Add info.rkt supplying (define collection 'multi) to be compatible
  with Racket 5.3.5 and 5.3.6.
- Add main.rkt re-providing parse.rkt so users can write
  simply (require parsack).
