### PR TITLE
Change oneOfStrings result type, and provide case-insensitive alternatives for various

### DIFF
--- a/parsack/parsack.scrbl
+++ b/parsack/parsack.scrbl
@@ -104,13 +104,17 @@ Parsec implementation in Racket. See @cite["parsec"].
 @defproc[(satisfy [p? (-> any/c boolean?)]) parser?]{
   Creates a parser that consumes and returns one character if it satisfies predicate @racket[p?].}
 @defproc[(char [c char?]) parser?]{
-  Creates a parser that parses char @racket[c].}
+  Creates a parser that parses char @racket[c], case-sensitive.}
+@defproc[(charAnyCase [c char?]) parser?]{
+  Creates a parser that parses char @racket[c], case-insensitive.}
 @defproc[(noneOf [str string?]) parser?]{
   Creates a parser that consumes and returns one character if the character does not appear in @racket[str].}
 @defproc[(oneOf [str string?]) parser?]{
   Creates a parser that consumes and returns one character if the character appears in @racket[str].}
 @defproc[(oneOfStrings [str string?] ...) parser?]{
-  Creates a parser that consumes and returns any of the @racket[str]s.}
+  Creates a parser that consumes and returns any of the @racket[str]s, case-sensitive. Note that the parse result is @racket[(listof char?)] not @racket[string?].}
+@defproc[(oneOfStringsAnyCase [str string?] ...) parser?]{
+  Creates a parser that consumes and returns any of the @racket[str]s, case-insensitive. Note that the parse result is @racket[(listof char?)] not @racket[string?].}
 @defproc[(string [str string?]) parser?]{
   Creates a parser that parses but does not return @racket[str].}
 
@@ -166,8 +170,8 @@ A @deftech{parser} is a function that consumes a @racket[State] and returns eith
 @defstruct*[Msg ([pos Pos?][unexpected string?][expected (listof string?)])]{
   Indicates parse error.}
 
-@defstruct*[Pos ([pos exact-nonnegative-integer?]
-                 [ln (or/c exact-nonnegative-integer? #f)]
+@defstruct*[Pos ([ofs exact-nonnegative-integer?]
+                 [line (or/c exact-nonnegative-integer? #f)]
                  [col (or/c exact-nonnegative-integer? #f)])]{
   Position of parser, with line and column information if it's available.}
 

--- a/parsack/tests/parsack-tests.rkt
+++ b/parsack/tests/parsack-tests.rkt
@@ -19,7 +19,27 @@
 
 (check-parsing ((char #\A) "A") "A" "")
 (check-parsing ((char #\A) "ABC") "A" "BC")
-(check-parse-error ((char #\A) "B") (fmt-err-msg 1 1 1 "B" (list "A")))
+(check-parse-error ((char #\A) "B")
+                   (fmt-err-msg 1 1 1 "B" (list "A")))
+
+(check-parsing ((charAnyCase #\A) "A") "A" "")
+(check-parsing ((charAnyCase #\A) "a") "a" "")
+(check-parse-error ((charAnyCase #\A) "Z")
+                   (fmt-err-msg 1 1 1 "Z" (list "A" "a")))
+
+(check-parsing ((string "ABC") "ABC") "ABC" "")
+(check-parsing ((string "ABC") "ABCxxx") "ABC" "xxx")
+(check-parse-error ((string "ABC") "xzy")
+                   (fmt-err-msg 1 1 1 "x" (list "A")))
+
+(check-parsing ((stringAnyCase "ABC") "ABC") "ABC" "")
+(check-parsing ((stringAnyCase "ABC") "abc") "abc" "")
+(check-parsing ((stringAnyCase "ABC") "ABC___") "ABC" "___")
+(check-parsing ((stringAnyCase "ABC") "abc___") "abc" "___")
+(check-parse-error ((stringAnyCase "ABC") "xzy")
+                   (fmt-err-msg 1 1 1 "x" (list "A" "a")))
+(check-parse-error ((stringAnyCase "ABC") "xzy")
+                   (fmt-err-msg 1 1 1 "x" (list "A" "a")))
 
 (check-parsing ($letter "A") "A" "")
 (check-parsing ($letter "b") "b" "")
@@ -30,18 +50,24 @@
 
 (check-parsing ($digit "1") "1" "")
 (check-parsing ($alphaNum "1") "1" "")
-(check-parse-error ($alphaNum "!") (fmt-err-msg 1 1 1 "!" (list "letter or digit")))
+(check-parse-error ($alphaNum "!")
+                   (fmt-err-msg 1 1 1 "!" (list "letter or digit")))
 
-(check-parse-error ((noneOf "a") "a") (fmt-err-msg 1 1 1 "a" (list "a") #:extra "none of"))
+(check-parse-error ((noneOf "a") "a")
+                   (fmt-err-msg 1 1 1 "a" (list "a") #:extra "none of"))
 (check-parsing ((noneOf "a") "b") "b" "")
-(check-parse-error ((noneOf "ab") "a") (fmt-err-msg 1 1 1 "a" (list "a" "b") #:extra "none of"))
-(check-parse-error ((noneOf "ab") "b") (fmt-err-msg 1 1 1 "b" (list "a" "b") #:extra "none of"))
+(check-parse-error ((noneOf "ab") "a")
+                   (fmt-err-msg 1 1 1 "a" (list "a" "b") #:extra "none of"))
+(check-parse-error ((noneOf "ab") "b")
+                   (fmt-err-msg 1 1 1 "b" (list "a" "b") #:extra "none of"))
 (check-parsing ((noneOf "ab") "c") "c" "")
 
 (check-empty-parsing ($eof "") "")
-(check-parse-error ($eof "a") (fmt-err-msg 1 1 1 "non-empty-input" "end-of-file"))
+(check-parse-error ($eof "a")
+                   (fmt-err-msg 1 1 1 "non-empty-input" "end-of-file"))
 (check-parsing ($eol "\n") "\n" "")
-(check-parse-error ($eol "a") (fmt-err-msg 1 1 1 "a" "end-of-line"))
+(check-parse-error ($eol "a")
+                   (fmt-err-msg 1 1 1 "a" "end-of-line"))
 
 (check-parsing ((>> $eol $eof) "\n\r") "" "")
 (check-parsing ((>> $eol $eof) "\n") "" "")
@@ -99,3 +125,13 @@
                    (fmt-err-msg 1 3 3 "" (list "e")))
 (check-parse-error ((many1Till (string "one") (string "two")) "ontwo")
                    (fmt-err-msg 1 3 3 "" (list "e")))
+
+(check-parsing ((oneOfStrings "foo" "bar" "baz") "bar") "bar" "")
+(check-parsing ((oneOfStrings "foo" "bar" "baz") "bar___") "bar" "___")
+(check-parse-error ((oneOfStrings "foo" "bar" "baz") "BAR")
+                   "parse-error: at 1:1:1\nunexpected: \"B\"\n  expected: \"one of: \\\"foo\\\", \\\"bar\\\", \\\"baz\\\"\"")
+
+(check-parsing ((oneOfStringsAnyCase "foo" "bar" "baz") "BAR") "BAR" "")
+(check-parsing ((oneOfStringsAnyCase "foo" "bar" "baz") "BAR___") "BAR" "___")
+(check-parse-error ((oneOfStrings "foo" "bar" "baz") "XXX")
+                   "parse-error: at 1:1:1\nunexpected: \"X\"\n  expected: \"one of: \\\"foo\\\", \\\"bar\\\", \\\"baz\\\"\"")


### PR DESCRIPTION
- Change oneOfStrings to return (listof char?) not string?
- Add charAnyCase. Like char, but case insensitive.
- Add stringAnyCase. Like string, but case insensitive.
- Add oneOfStringsAnyCase. Like oneOfStrings, but case insensitive.
- Refactor oneOf and noneOf to share common code.
- Fix doc of Pos field names. While I'm at it, change the first field
  (previously called `pos` in the docs but `x` in the code) to be
  named `ofs`, which I think is clearest. Errors are often reported in
  terms of line, column, and absolute offset. So I think `ofs` is a
  good name.

**NOTE:** Even though I'm a collaborator on this repo now (thanks again!) these were enough changes, and we'd only really discussed one of them, that I felt better doing this as a pull request so you could review (if you want).
