### PR TITLE
`parse-result` should handle (Empty (OK _ _ _)).

### DIFF
--- a/parsack/parsack.rkt
+++ b/parsack/parsack.rkt
@@ -348,6 +348,7 @@
 (define (parse-result p s)
   (match (parse p s)
     [(Consumed! (Ok parsed _ _)) parsed]
+    [(Empty     (Ok parsed _ _)) parsed]
     [x (error 'parse-result (~v x))]))
 
 ;; parser compose


### PR DESCRIPTION
Using randomized testing of my markdown parser, I discovered that
sometimes I would get this error:

; parse-result: (Empty (Ok '() (State "" #0=(Pos 0 0 0)) (Msg #0# "end
  of input" '("space or tab" "new-line" "block" "space or tab"
  "new-line" "end-of-file"))))

However the parse result should have been OK. It would have been a
sensible result for the input.

`parse-result` was expecting only (Consumed (OK)) and treating all
else as an error.  I think it should also handle (Empty (Ok)).

In fact I wonder if it needs to because `lookAhead` can now return
something of the form (Empty (Ok)), as a result of:
https://github.com/stchang/parsack/pull/17

FWIW, after making the change in this commit, I ran Parsack's tests,
as well as my markdown tests, including more of the randomized ones.
All passed.

Even so, I'd appreciate your review. Not only do I want to make sure
it's correct, I wonder if I've overlooked other places that should be
changed similarly?
