### PR TITLE
Fix result to str

### DIFF
--- a/parsack/parsack.rkt
+++ b/parsack/parsack.rkt
@@ -196,10 +196,12 @@
        [emp emp])]))
 
 ;; converts intermediate parse result to string -- for err purposes
+;; Note: Efficiency of this matters, it may be called frequently.  The
+;; following is fast-enough but will fail 3 tests for nicely formatted
+;; error messages. Hot fix.
 (define (result->str res)
-  (cond [(list? res) (string-join (map ~a res) "")]
-        [(char? res) (mk-string res)]
-        [else (~a res)]))
+  (cond [(char? res) (mk-string res)]
+        [else res]))
 
 (define (<!> p [q $anyChar]) 
   (match-lambda 


### PR DESCRIPTION
Please note the two commits. The first one passes the tests, but is too slow. The second one doesn't pass the tests (the messages aren't formatted nicely) but is fast-enough and passes all of Parsack's tests as well as the downstream markdown parser tests.

I'm hoping maybe this "hot fix" is OK and we could loop back later to figure out how to get the nice messages, fast?
