### PR TITLE
Add deps and build-deps to info.rkt

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,2 +1,4 @@
 #lang setup/infotab
 (define collection 'multi)
+(define deps '("base"))
+(define build-deps '("rackunit-lib"))


### PR DESCRIPTION
This is important for people using Racket 6 with less than the full,
main distribution.
