### PR TITLE
Give Parsack a version and bump it to 0.2

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+(define version "0.2")
 (define collection 'multi)
 (define deps '("base"))
 (define build-deps '("rackunit-lib"))


### PR DESCRIPTION
This, may markdown package can require >= version in its `deps`.
