### PR TITLE
Add info.rkt for the parsack collection.

### DIFF
--- a/parsack/info.rkt
+++ b/parsack/info.rkt
@@ -1,0 +1,3 @@
+#lang setup/infotab
+(define name "parsack")
+(define scribblings '(("parsack.scrbl" ())))


### PR DESCRIPTION
For scribblings. See issue #42. Although I think adding this is
necessary, I'm not sure it's sufficient: Although I do now see
`raco setup parsack` building parsack.scrbl, and an XREPL
`,doc parse-result` works, I don't see it using Search in the web
browser. So either something else remains to be done, or, it was
sufficient and I just have a stale cache.
