### PR TITLE
Feature Specific Profile Support

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -2,7 +2,6 @@
 (define version "0.3")
 (define collection 'multi)
 (define deps '("base"
-               "feature-profile"
                "profile-lib"))
 (define build-deps '("rackunit-lib"
                      "scribble-lib"

--- a/parsack/features.rkt
+++ b/parsack/features.rkt
@@ -1,7 +1,18 @@
 #lang racket
-(require feature-profile
-         feature-profile/plug-in-lib
-         profile/analyzer
+;(require feature-profile
+;         feature-profile/plug-in-lib
+;         profile/analyzer
+;         (only-in profile/render-text render))
+
+(define feature (dynamic-require 'feature-profile/plug-in-lib 'feature))
+(define make-interner (dynamic-require 'feature-profile/plug-in-lib 'make-interner))
+(define feature-report-core-samples
+  (dynamic-require 'feature-profile/plug-in-lib 'feature-report-core-samples))
+(define feature-report-raw-samples
+  (dynamic-require 'feature-profile/plug-in-lib 'feature-report-raw-samples))
+(define feature-report-total-time
+  (dynamic-require 'feature-profile/plug-in-lib 'feature-report-total-time))
+(require profile/analyzer
          (only-in profile/render-text render))
 
 (provide (all-defined-out))

--- a/parsack/main.rkt
+++ b/parsack/main.rkt
@@ -1,5 +1,3 @@
 #lang racket
-(require "parsack.rkt"
-         "features.rkt")
-(provide (all-from-out "parsack.rkt")
-         (all-from-out "features.rkt"))
+(require "parsack.rkt")
+(provide (all-from-out "parsack.rkt"))


### PR DESCRIPTION
Parsers using Parsack can now use feature-specific profilers.

Documentation can be found at: http://pkg-build.racket-lang.org/doc/feature-profile/index.html

Use parsack-features in #:extra-features.
