### PR TITLE
Fix parser-compose in parsack.scribl

### DIFF
--- a/parsack/parsack.scrbl
+++ b/parsack/parsack.scrbl
@@ -72,7 +72,7 @@ Parsec implementation in Racket. See @cite["parsec"].
      "(a)")]}
 
 
-@defform/subs[(parser-compose bind-or-skip ...)
+@defform/subs[(parser-compose bind-or-skip ...+)
               ([bind-or-skip (x <- parser) parser]
                [parser parser?]
                [x identifier?])]{


### PR DESCRIPTION
Implementation requires a minimum of one parser in parser-compose
