### PR TITLE
Use thread cells for global state

### DIFF
--- a/parsack/parsack.rkt
+++ b/parsack/parsack.rkt
@@ -68,25 +68,25 @@
 ;; global parameters ----------------------------------------------------------
 ;; current-unexpected : [Thunk String]
 ;; The current unexpected char.
-(define current-unexpected "")
-(define (reset!-unexpected) (set! current-unexpected ""))
-(define (get-unexpected) current-unexpected)
-(define (set!-unexpected str) (set! current-unexpected str))
+(define current-unexpected (make-thread-cell ""))
+(define (reset!-unexpected) (thread-cell-set! current-unexpected ""))
+(define (get-unexpected) (thread-cell-ref current-unexpected))
+(define (set!-unexpected str) (thread-cell-set! current-unexpected str))
 ; current-expected : [List [Thunk String]]
 ;; The current expected chars.
-(define current-expected null)
-(define (reset!-expected) (set! current-expected null))
-(define (get-expected) current-expected)
-(define (set!-expected exps) (set! current-expected exps))
+(define current-expected (make-thread-cell null))
+(define (reset!-expected) (thread-cell-set! current-expected null))
+(define (get-expected) (thread-cell-ref current-expected))
+(define (set!-expected exps) (thread-cell-set! current-expected exps))
 (define (merge!-expected exps1 exps2) (set!-expected (append exps1 exps2)))
-(define (cons!-expected exp) (set!-expected (cons exp current-expected)))
-(define (append!-expected exps) (set!-expected (append exps current-expected)))
+(define (cons!-expected exp) (set!-expected (cons exp (get-expected))))
+(define (append!-expected exps) (set!-expected (append exps (get-expected))))
 ;; user-state [MutHashEq Sym => X]
 ;; state customizable by the user
-(define user-state (make-hasheq))
-(define (user-state-reset!) (set! user-state (make-hasheq)))
-(define (user-state-get key) (hash-ref user-state key #f))
-(define (user-state-set! key val) (hash-set! user-state key val))
+(define user-state (make-thread-cell (make-hasheq)))
+(define (user-state-reset!) (thread-cell-set! user-state (make-hasheq)))
+(define (user-state-get key) (hash-ref (thread-cell-ref user-state) key #f))
+(define (user-state-set! key val) (hash-set! (thread-cell-ref user-state) key val))
 
 ;; errors ---------------------------------------------------------------------
 (define (err expected)

--- a/parsack/tests/parsack-tests.rkt
+++ b/parsack/tests/parsack-tests.rkt
@@ -247,7 +247,7 @@
              ""))))
 
 (check-equal? (thread-receive) 1) ; resume when subthread has state
-(check-equal? (parse-result $setCount "") 1) ; try to destroy it
+(check-equal? (parse-result $setCount "") 1) ; implied (user-state-reset!)
 (thread-send sub-thread 'continue) ; let subthread finish
 (check-equal? (thread-receive) 3) ; confirm that subthread was undisturbed.
 


### PR DESCRIPTION
Re: https://github.com/stchang/parsack/issues/50#issuecomment-590435790

Adding thread cells do have an impact on performance. These timings below are derived by running  `parse-markdown` as bytecode on a single 564K Markdown file on my machine.

`master`:
```
real    (mean 1.485s) 0m1.473s 0m1.480s 0m1.498s 0m1.468s 0m1.507s
user    (mean 1.412s) 0m1.387s 0m1.416s 0m1.434s 0m1.392s 0m1.430s
sys     (mean 0.068s) 0m0.081s 0m0.059s 0m0.059s 0m0.070s 0m0.072s
```

`thread-cells`:
```
real    (mean 1.589s) 0m1.568s 0m1.596s 0m1.571s 0m1.604s 0m1.604s
user    (mean 1.509s) 0m1.490s 0m1.513s 0m1.499s 0m1.514s 0m1.531s
sys     (mean 0.074s) 0m0.073s 0m0.078s 0m0.067s 0m0.084s 0m0.068s
```

I'm currently unsure about how to write a reliable test that verifies that no two threads interfere with each other. I think what I might do is create a user state with a counter, and confirm that 2 threads started at different times each parse 1000 characters and end up on position 1001 or something.

Obviously do not approve until I get a test in, but I want to know if you'd want a global switch to let the user specify shared state. That might save the performance, but it makes the interface a little more awkward ("Oh, are you multithreaded? Configure the library first")